### PR TITLE
[No ticket] Add core/missing block selector to the conditions

### DIFF
--- a/convert-blocks.js
+++ b/convert-blocks.js
@@ -1644,7 +1644,9 @@ function process_post(post) {
             // then serialize that blocks (it should be a freeform probably)
             // and pass it again to rawHandler to break it down to blocks.
             // This way freeform blocks will be broken down to smaller blocks, like paragraphs.
-            if (!block.name.includes('planet4') && !block.name.includes('freeform')) {
+            if (!block.name.includes('planet4')
+                 && !block.name.includes('missing')
+                 && !block.name.includes('freeform')) {
 
                 // try {
 
@@ -1653,7 +1655,10 @@ function process_post(post) {
                     // console.log(temp_content);
                     temp_blocks = wpblocks.rawHandler({HTML: temp_content});
                     // console.log(temp_blocks);
-                    temp_blocks = wpblocks.rawHandler({HTML: wpblocks.getBlockContent(temp_blocks[0])});
+
+                    if (temp_blocks[0]) {
+                        temp_blocks = wpblocks.rawHandler({HTML: wpblocks.getBlockContent(temp_blocks[0])});
+                    }
                     // console.log(temp_blocks);
                     // block = temp_blocks[0];
                     // console.log(temp_blocks);


### PR DESCRIPTION
This checks for the `missing` keyword in the block's name. When the converter tries to parse a non-registered block like the ones from GPCH, it gives the block a `core/missing` name, in which case we just pass it down as it is. 

This was the case for one of the conversions failing in @kirdia 's  environment (theia). Original post: https://k8s.p4.greenpeace.org/theia/wp-admin/post.php?post=446&action=edit

Somehow it also fails to parse the attributes for the `core/tag-cloud` block, so these are stripped out in the conversion, the code goes from: 

`<!-- wp:tag-cloud {"taxonomy":"p4-page-type","showTagCounts":true} /-->` to `<!-- wp:tag-cloud /-->`

Original post: https://k8s.p4.greenpeace.org/theia/wp-admin/post.php?post=537&action=edit

-----

Despite that, some conversion errors were found (sorry, the URLs are from my env, you can search for the titles in the release environment, I imported the posts from there):

https://www.planet4.test/uncategorised/25224/what-lies-beneath-blackwater-the-sargasso-sea/
- Unconverted shortcode visible in the page: `[shortcake_take_action_boxout take_action_page='22048' /]`

<img width="1239" alt="Captura de pantalla 2019-10-29 a la(s) 01 07 12" src="https://user-images.githubusercontent.com/340766/67741186-0f461400-f9f7-11e9-8f50-1088c295d7d1.png">

https://www.planet4.test/issues/nature/24511/new-ipcc-report-shows-critical-need-for-accelerated-climate-action-and-oceans-protection/
- Links were treated as paragraphs, causing line-breaks.

<img width="570" alt="Captura de pantalla 2019-10-29 a la(s) 01 37 04" src="https://user-images.githubusercontent.com/340766/67741203-1bca6c80-f9f7-11e9-8875-05d067783561.png">


https://www.planet4.test/issues/people/24474/the-best-signs-from-the-global-climate-strike-on-september-20th/
- Image captions rendered as "Medium" style instead of "Blue Overlay".

<img width="1032" alt="Captura de pantalla 2019-10-29 a la(s) 01 39 30" src="https://user-images.githubusercontent.com/340766/67741214-26850180-f9f7-11e9-8410-7479307b85d0.png">


https://www.planet4.test/issues/people/24385/live-september-a-month-of-action-for-the-climate/
- Some Twitter shortcodes were converted to empty shortcode blocks.

<img width="734" alt="Captura de pantalla 2019-10-29 a la(s) 02 02 34" src="https://user-images.githubusercontent.com/340766/67741224-2c7ae280-f9f7-11e9-9e5e-ac99df56bb95.png">

